### PR TITLE
Addition of missing requirements to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,12 @@ config = {
     'download_url': 'https://github.com/screepers/screeps-api/releases',
     'author_email': 'tedivm@tedivm.com',
     'version': '0.2',
-    'install_requires': ['nose', 'requires'],
+    'install_requires': [
+        'nose', 
+        'requires', 
+        'requests>=2.10.0,<3',
+        'websocket-client'
+        ],
     'packages': ['screepsapi'],
     'scripts': [],
     'name': 'screepsapi'


### PR DESCRIPTION
Hi there!

It seems that there were some missing dependencies in the project, namely request and websocket. As a result executing `pip install -e git+https://github.com/puciek/python-screeps.git#egg=screepsapi-dev` on clean virtualenv passed the installation but subsequently opening the terminal and calling `import screepsapi` resulted in first an import error regarding `requests`. When that was satisfied then it was complaining about lack of `websocket-client`.
You can reproduce this issue by running the installation command on clear virtualenv, make sure to not import your existing packages when creating it.

This simple addition to setup.py (and minor reformat as the list grew long-ish) seems to fix that issue.