### PR TITLE
Update user_find to support finding users by id

### DIFF
--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -110,6 +110,9 @@ are the ones listed below.
 - `https://screeps.com/api/user/find?username=danny`
     - `{ ok, user: { _id, username, badge: { type, color1, color2, color3, param, flip }, gcl } }`
 
+- `https://screeps.com/api/user/find?id=55c91dc66e36d62a6167e1b5`
+    - `{ ok, user: { _id, username, badge: { type, color1, color2, color3, param, flip }, gcl } }`
+
 - `https://screeps.com/api/user/overview?interval=1440&statName=energyControl`
     - `{ ok, rooms: [ <room name> ], stats: { <room name>: [ { value, endTime } ] }, statsMax }`
 

--- a/screepsapi/screepsapi.py
+++ b/screepsapi/screepsapi.py
@@ -52,8 +52,12 @@ class API(object):
     def stats(self,id,interval=8):
         return self.get('user/stats',id=id,interval=interval)
 
-    def user_find(self, username):
-        return self.get('user/find', username=username)
+    def user_find(self, username=None, user_id=None):
+        if username is not None:
+            return self.get('user/find', username=username)
+        if user_id is not None:
+            return self.get('user/find', id=user_id)
+        return False
 
     def user_rooms(self, userid):
         return self.get('user/rooms', id=userid)


### PR DESCRIPTION
This adds a `user_id` option to `user_find`. The way multiple parameters are handled is based off of the way the current `battles` method handles the situation.

I don't believe this will break backwards compatibility.