### PR TITLE
Update the experimental/pvp API call to include the 'start' param

### DIFF
--- a/docs/Endpoints.md
+++ b/docs/Endpoints.md
@@ -47,6 +47,15 @@ are the ones listed below.
     - `status` can at least be "normal" or "out of borders"
     - if the room is in a novice area, `novice` will contain the Unix timestamp of the end of the protection (otherwise it is absent)
 
+- `https://screeps.com/api/experimental/pvp?interval=50`
+    - `{ ok, time, rooms: [ { _id, lastPvpTime } ] }`
+    - `time` is the current server tick
+    - `_id` contains the room name for each room, and `lastPvpTime` contains the last tick pvp occurred
+    - if neither a valid `interval` nor a valid `start` argument is provided, the result of the call is still `ok`, but with an empty rooms array.
+
+- `https://screeps.com/api/experimental/pvp?start=14787157`
+    - `{ ok, time, rooms: [ { _id, lastPvpTime } ] }`
+
 # Market information
 
 - `https://screeps.com/api/game/market/orders-index`

--- a/screepsapi/screepsapi.py
+++ b/screepsapi/screepsapi.py
@@ -164,9 +164,9 @@ class API(object):
 
     #### battle info methods
 
-    def battles(self, interval=None, sinceTick=None):
+    def battles(self, interval=None, start=None):
         if sinceTick is not None:
-            return self.get('experimental/pvp', sinceTick=sinceTick)
+            return self.get('experimental/pvp', start=start)
         if interval is not None:
             return self.get('experimental/pvp', interval=interval)
         return False


### PR DESCRIPTION
While 'sinceTick' was suggested by dissi in the community discussion, the server only responds to the 'start' parameter.

This also adds documentation for the endpoint in Endpoints.md, including the fact that the server will simply return a successful API call if neither `interval` nor `start` is provided.