### PR TITLE
Fix requirement of incorrect Websocket library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-
 requests>=2.10.0,<3
-websocket==0.2.1
+websocket-client==0.37.0


### PR DESCRIPTION
Fixed reference to dead websocket library https://pypi.python.org/pypi/websocket/ instead of https://pypi.python.org/pypi/websocket-client/.