### PR TITLE
Fix bug introduced in f47f5d6a6f83c363b205bfa0d0d96c73948618ff

### DIFF
--- a/screepsapi/screepsapi.py
+++ b/screepsapi/screepsapi.py
@@ -172,7 +172,7 @@ class API(object):
     #### battle info methods
 
     def battles(self, interval=None, start=None):
-        if sinceTick is not None:
+        if start is not None:
             return self.get('experimental/pvp', start=start)
         if interval is not None:
             return self.get('experimental/pvp', interval=interval)


### PR DESCRIPTION
My previous contribution, f47f5d6a6f83c363b205bfa0d0d96c73948618ff, seems to have completely broken the battles() API method!

My apologies for this, I seem to not have successfully tested it until now.