### PR TITLE
Fix For `board_list` when `season` is None

### DIFF
--- a/screepsapi/screepsapi.py
+++ b/screepsapi/screepsapi.py
@@ -236,7 +236,7 @@ class API(object):
     def board_list(self, limit=10, offset=0, season=None, mode='world'):
         if season is None:
             ## find current season (the one with max start time among all seasons)
-            seasons = self.board_seasons['seasons']
+            seasons = self.board_seasons()['seasons']
             season = max(seasons, key=lambda s: s['date'])['_id']
 
         ret = self.get('leaderboard/list', limit=limit, offset=offset, mode=mode, season=season)


### PR DESCRIPTION
The `self.board_seasons` is a method but is being indexed. Instead,
it was intended that the return value of the method be indexed and
this fix corrects that.